### PR TITLE
Update documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Bellman search utility for Game Of Life with windows support.
 
 To use BellmanReport.py place the script into golly scirpt folder together with bellman.exe. 
 
-For general information and introduction on bellman usage take a look at the [original bellman documentation](http://sourceforge.net/projects/bellman/files/?source=navbar)
+For general information and introduction on bellman usage take a look at the [original bellman documentation](https://github.com/rokicki/lifecontent/blob/master/bellman/bellman-B-2014-08-02.pdf)


### PR DESCRIPTION
The original Bellman site on Sourceforge is out-of-date and potentially confusing; I'd like to take it down.
This patch updates the documentation link to point at a copy that's not about to disappear.